### PR TITLE
Dev-Params ---> Staging

### DIFF
--- a/.github/workflows/auto.yaml
+++ b/.github/workflows/auto.yaml
@@ -5,8 +5,14 @@ on:
     branches:
       - main
       - staging
+      - 'dev-*'
+      - 'bugfix-*'
+      - 'feature-*'
+      - 'feat-*'
+
     paths:
       - '*'
+
     # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
     types:
       - assigned

--- a/README.md
+++ b/README.md
@@ -117,37 +117,53 @@ To use phpytex, a `.phpytex.yaml` file is required in the (root of) the project 
 This should contain 4 parts with the following structure:
 
 ```yaml
-########################################
+# ----------------------------------------------------------------
 # COMPILE OPTIONS
-########################################
+# ----------------------------------------------------------------
+
 compile:
   options:
-    root:   root.tex
+    root: root.tex
     output: main.tex
+    debug: false
+    compile-latex: false
+    comments: auto
+    tabs: false
+    spaces: 4
     ...
-########################################
+
+# ----------------------------------------------------------------
 # STAMP OPTIONS (optional)
-########################################
+# ----------------------------------------------------------------
+
 stamp:
-  file:      stamp.tex
+  file: stamp.tex
   overwrite: true
   options:
     ...
-########################################
+
+# ----------------------------------------------------------------
 # DOCUMENT PARAMETERS (optional)
-########################################
+# ----------------------------------------------------------------
+
 parameters:
   file: src.parameters
   overwrite: true
   options:
-  ...
-########################################
-# DOCUMENT TREE (optional)
-########################################
+    ...
+
+# ----------------------------------------------------------------
+# PROJECT TREE (optional)
+# ----------------------------------------------------------------
+
 files:
-  ...
-folders:
-  ...
+  - "file1"
+  - "file2"
+  - ...
+
+folders: # values are recursive files-folder structure
+  subfolder1: { ... }
+  subfolder1: { ... }
 ```
 
 See [LONGREADME.md](./LONGREADME.md#usage-short_config) for more details

--- a/src/features/feature_transpile/steps/step_create.py
+++ b/src/features/feature_transpile/steps/step_create.py
@@ -109,8 +109,22 @@ def create_file_stamp(
 
 
 def create_parameter_encoding(options: dict[str, Any]):
+    # unparse key-values
+    data = [
+        (name, value, parser_python.unparse(value, indent=0, multiline=False))
+        for name, value in options.items()
+    ]
+    # clean keys
     user.EXPORT_VARS = {
-        key: (value, parser_python.unparse(value, indent=0, multiline=False))
-        for key, value in options.items()
+        clean_var_name(name): (value, coded_value) for name, value, coded_value in data
     }
     return
+
+
+# ----------------------------------------------------------------
+# AUXILIARY METHODS
+# ----------------------------------------------------------------
+
+
+def clean_var_name(key: str) -> str:
+    return re.sub(r'[^a-z0-9\_]', '_', key, flags=re.IGNORECASE)

--- a/src/features/feature_transpile/steps/step_transpile.py
+++ b/src/features/feature_transpile/steps/step_transpile.py
@@ -227,26 +227,24 @@ def createImportFileParameters(
 ):
     if os.path.exists(path) and not overwrite:
         return
-    lines = re.split(
-        r'\r?\n',
-        dedent(
-            '''
+
+    lines = []
+    lines += dedent_split(
+        '''
         #!/usr/bin/env python3
         # -*- coding: utf-8 -*-
 
         from fractions import Fraction;
         '''
-        ),
     )
     lines.append('')
-    names = user.EXPORT_VARS.keys()
-    for name, (_, codedvalue) in user.EXPORT_VARS.items():
-        lines.append(f'{name} = {codedvalue};')
-    for name in documents.variables.keys():
-        if name in names:
-            continue
-        lines.append(f'{name} = None;')
+
+    data = {key: None for key, value in documents.variables.items()} | {
+        key: coded_value for key, (_, coded_value) in user.EXPORT_VARS.items()
+    }
+    lines += [f'{key} = {coded_value}' for key, coded_value in data.items()]
     lines.append('')
+
     write_text_file(path=path, lines=lines)
     return
 

--- a/src/models/transpilation/type_transpiledocument.py
+++ b/src/models/transpilation/type_transpiledocument.py
@@ -149,8 +149,6 @@ class TranspileDocuments(object):
     edges: list[tuple[str, str]]
     docEdges: list[tuple[str, str]]
 
-    variables: list[str]
-
     def __init__(self, root: str, indentsymb: str, schemes: dict[str, str] = dict()):
         self.root = root
         self.indentsymb = indentsymb
@@ -443,7 +441,10 @@ class TranspileDocuments(object):
                 label='{label}_{name}'.format(label=self.schemes['pre'], name=name),
             )
             yield from blocks.generateCode(
-                offset=offset + 1, anon=False, hide=False, align=align
+                offset=offset + 1,
+                anon=False,
+                hide=False,
+                align=align,
             )
             yield '{tab}return'.format(tab=self.tab(offset + 1))
 

--- a/tests/cases/case_no-compile_simple/.phpytex.yaml
+++ b/tests/cases/case_no-compile_simple/.phpytex.yaml
@@ -33,7 +33,7 @@ stamp:
 parameters:
   overwrite: true
   options:
-    FONT_SIZE: 12pt
+    FONT-SIZE: 12pt # this will be 'cleaned' to FONT_SIZE inside parameters.py
     TITLE:     *ref_title
     KEYWORDS:
       - ai


### PR DESCRIPTION
Now allow users to use hyphenated keys in user config (`.phpytex.yaml`). When parse, these are cleaned so that they can be used in code. E.g.

```yaml
# .phpytex.yaml
...
parameters:
  file: src.params
  overwrite: ...
  options:
    ...
    author-name: "Maximilian Ulysses"
    author-surname: "Mustermann"
    page_language-list:
      - en-GB
      - de-DE
      - fr-FR
    ...
...
```

transpiles to

```py
# src/params.py
...
author_name = "Maximilian Ulysses"
author_surname = "Mustermann"
page_language_list = [ "en-GB", "de-DE", "fr-FR" ]
...
```